### PR TITLE
fix: lambda scope frame leak breaking recursion with multiple self-calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ There are two evaluation backends with identical language semantics: the codegen
 - Shared compile-time checks live in `validate.ts` — change once, both backends enforce it.
 - Backend-specific control flow: `visitors.ts` `traverse()` emits code strings; `interpreter.ts` `evalNode()` returns values. A new AST node or changed evaluation rule must be mirrored in both.
 
-The **parity test suite is the synchronization gate**: `test/helpers.ts` exports a parity-`compile` that builds each expression with both backends and asserts identical construction, results, and error type/message; value-oriented suites run every case through both. If a semantics change touches only one backend, parity tests fail. `test/interpreter.test.ts` additionally covers eval-free-specific behavior (CSP stub, node-located errors).
+The **parity test suite is the synchronization gate**: `test/helpers.ts` exports a parity-`compile` that builds each expression with both backends and asserts identical construction, results, and error type/message; value-oriented suites run every case through both. If a semantics change touches only one backend, parity tests fail. `test/interpreter.test.ts` additionally covers eval-free-specific behavior (CSP stub, node-located errors). `test/semantics-guards.test.ts` pins behaviors that the codegen optimizations planned in `docs/compiler-roadmap.md` could silently break (pipe topic capture by closures, codegen-internal name collisions, identifier resolution semantics, `??` nesting) — consult it before implementing any roadmap item.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -389,19 +389,22 @@ countdown(3)   // [3, 2, 1]
 let x = x + 1, x   // Error: x is not defined
 ```
 
-**No mutual recursion.** Two sibling `let` bindings cannot see each other — each `let` opens a new scope, and the name becomes visible only for bindings that follow it. Combine both functions into one with a selector parameter, or use the `self(self)` trick below.
-
-**Multi-branch recursion (Fibonacci, tree traversal).** When the recursive case combines two or more recursive calls in a single expression, bind each call with `let` first:
+**Mutual recursion works between sibling bindings.** All bindings of one `let` share a scope. Initializers see only *previous* bindings, but a lambda body resolves names at call time — by then every sibling is established:
 
 ```
-let fib = n =>
-  if n <= 1 then n
-  else
-    let a = fib(n - 1),
-        b = fib(n - 2),
-    a + b,
+let even = n => if n == 0 then true else odd(n - 1),
+odd = n => if n == 0 then false else even(n - 1),
+even(10)   // true
+```
+
+**Multi-branch recursion (Fibonacci, tree traversal)** works directly — two or more recursive calls in one expression are fine:
+
+```
+let fib = n => if n <= 1 then n else fib(n - 1) + fib(n - 2),
 fib(10)   // 55
 ```
+
+Binding each recursive call with `let` first (`let a = fib(n - 1), b = fib(n - 2), a + b`) is a stylistic choice for busy recursive cases, not a requirement.
 
 **Anonymous recursion** — for cases where a name isn't available (e.g., inside a pipe stage):
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -232,14 +232,13 @@ let factorial = n => if n <= 1 then 1 else n * factorial(n - 1),
 factorial(5)                        // 120
 ```
 
-Self-reference works **only for lambdas** (`let x = x + 1, x` errors). **No mutual recursion** —
-sibling `let` bindings cannot see each other. For multi-branch recursion (Fibonacci, tree
-walks) bind each recursive call with `let` first:
+Self-reference works **only for lambdas** (`let x = x + 1, x` errors). Mutual recursion between
+sibling bindings works — lambda bodies resolve names at call time, so an earlier binding can
+call a later one (initializers still see only previous bindings). Multi-branch recursion
+(Fibonacci, tree walks) works directly:
 
 ```
-let fib = n =>
-  if n <= 1 then n
-  else let a = fib(n - 1), b = fib(n - 2), a + b,
+let fib = n => if n <= 1 then n else fib(n - 1) + fib(n - 2),
 fib(10)                             // 55
 ```
 

--- a/docs/compiler-roadmap.md
+++ b/docs/compiler-roadmap.md
@@ -17,6 +17,23 @@ If we commit to fixed core semantics, the compiler can emit much tighter code.
 This document surveys the current indirections introduced by extensibility and
 proposes inline/specialized alternatives with a performance estimate for each.
 
+> **Update (2026-07-04).** The "proper compiler-plugin mechanism" deferred by
+> the closing paragraph has since been designed: see `.research/001-plugins/`.
+> The proposals below become the *default lowering*; the override surface
+> listed under "extensibility that migrates to plugins" moves to compile-time
+> plugins (pay-per-use) instead of disappearing outright. Two rules for
+> implementing the items below:
+>
+> 1. **Every fast emission keeps a slow twin.** Implementing a fast path must
+>    not delete the alternative emission form — it becomes the branch for
+>    overridden operations (legacy `ContextOptions` during the transition,
+>    plugin slots after). The switch is flipped once per compile — a
+>    legacy/plugin check selects a whole visitor table — never via `if`s
+>    inside individual visitors.
+> 2. Items that *remove* public API ship together with the plugin mechanism
+>    (deprecation → removal in the next major), not with the performance
+>    work. The performance half of this roadmap can land first and alone.
+
 Legend for impact ratings:
 
 - **High** — measurable speedup on most expressions (eliminates per-op function
@@ -171,6 +188,12 @@ Fixed core semantics (always boolean, always short-circuit) make this safe.
 two closures. Eliminating those is a large win for any expression that uses
 boolean logic (which is most of them in conditional code paths).
 
+Plugin note: an override of `and`/`or` keeps the thunk signature
+`(l: () => unknown, r: () => unknown)` — short-circuiting is impossible to
+implement otherwise. Codegen therefore retains thunk emission as the slow
+twin for overridden logical operators; native `&&`/`||` is the default-path
+emission only.
+
 ---
 
 ## 4. Identifier lookup — `_get` walks a linked list
@@ -201,9 +224,18 @@ Issues:
 
 ### 4a. Cheap wins (no compiler rewrite)
 
-Replace `findIndex(it => it === name)` with `indexOf(name)`. One-line change.
-**Impact: High** — identifier lookup is the single hottest path in the
-runtime, and every call currently allocates a closure.
+1. Replace `findIndex(it => it === name)` with `indexOf(name)`. One-line
+   change. **Impact: High** — identifier lookup is the single hottest path
+   in the runtime, and every call currently allocates a closure.
+
+2. Drop the per-evaluation `_get.bind(data)`. The bootstrap does
+   `var get = _get.bind(data)` *inside* the returned `data => {...}` arrow —
+   so **every invocation of the compiled function allocates a fresh bound
+   function**, even for a trivial expression with one identifier. Fix: give
+   `_get` an explicit `data` parameter instead of `this`, and emit
+   `get(scope, "x", data)` at each identifier site. Zero per-call
+   allocation, no semantics change. **Impact: High, Effort: Trivial** —
+   same tier as the `indexOf` fix; do both together.
 
 ### 4b. Structural win — static scope resolution
 
@@ -221,10 +253,47 @@ references — so it emits the generic `get(scope, "x")` for all four.
 - **let binding** → emit the mangled JS variable name directly. The let
   codegen can switch from `_varValues.push(init)` to real JS `var`/`let`
   declarations.
-- **global** → emit `globals["x"]` (or even fold static globals at compile
-  time when they are known).
-- **data field** → emit `data["x"]`.
+- **global** → emit a direct lookup against the `globals` object (folding
+  static global *values* into the code is possible but changes observable
+  behavior — see the caveats below).
+- **data field** → emit `_dataGet(data, "x")` — **not** a raw `data["x"]`
+  (see the caveats below).
 - **unresolved** → fall back to `getIdentifierValue`, or throw `CompileError`.
+
+Two invariants (decided 2026-07-04, see `.plan/2026-07-04/fork-decisions.md`,
+fork 4):
+
+- **Static resolution of local bindings is unconditional.** Lambda params,
+  `let` bindings and the `%` topic are always emitted as real JS locals — no
+  override can affect them (the identifier hook is only ever consulted after
+  the local scope misses, by definition).
+- **Direct `globals["x"]` / `data["x"]` emission and static-globals folding
+  apply only when no plugin overrides the identifier hook.** With an
+  override present, every *free* identifier lowers to a single direct call
+  of the plugin fn; locals stay static regardless.
+
+Design note: the environment pass should bind *pattern → set of names*, not
+*parameter → single name* — destructuring in `let`/lambda params is an
+accepted candidate (`.research/004-syntax-extensions/`) and will need
+exactly that shape.
+
+Two semantics-preservation caveats (pinned by guard tests in
+`test/semantics-guards.test.ts`):
+
+- **Raw `data["x"]` is not equivalent to today's lookup.**
+  `defaultGetIdentifierValue` does an `Object.hasOwn` check
+  (prototype-pollution safety: inherited properties like `toString` must
+  stay invisible), throws `Unknown identifier` on a miss, and special-cases
+  the `undefined` identifier (returns `undefined` even when data has an own
+  `"undefined"` key). The direct emission must be a small
+  `_dataGet(data, "x")` helper that keeps all three; the win is skipping
+  the scope-chain walk, not the final guarded read.
+- **Globals are read by reference today.** Mutating the `globals` object
+  after `compile()` is visible to subsequent invocations. Folding global
+  *values* into the emitted code silently switches that to snapshot
+  semantics — either fold only the lookup (bind the object, read the
+  property at runtime) or make snapshotting an explicit, documented
+  decision first.
 
 This eliminates:
 
@@ -245,12 +314,23 @@ the `%` topic reference (which is today a lambda-scope-like binding created
 by pipes). All of those are tractable — `%` becomes a mangled local
 (`_t0`, `_t1` for nested pipes) just like a lambda param.
 
-### 4c. Drop `getIdentifierValue` from `ContextHelpers`
+History note: the runtime scope-chain mechanism this section removes has
+already produced one correctness bug — issue #30, where lambda codegen
+mutated the closure-captured `scope` variable per invocation, breaking
+recursion with multiple self-calls (fixed by binding the frame as a
+per-invocation local; see `docs/design-decisions.md`). The regression
+suite `test/recursion.test.ts` (fib, mutual recursion, Y combinator, …)
+must pass unchanged after the §4b rewrite.
 
-Once globals/data are resolved at compile time, `getIdentifierValue` no
-longer has to be an override point. Remove from `ContextHelpers`, keep a
-private helper. **Impact: Low** (cleanup, not a speedup), but simplifies
-the mental model.
+### 4c. Migrate `getIdentifierValue` to a plugin hook
+
+Once globals/data are resolved at compile time, the *default* lowering stops
+calling `getIdentifierValue` entirely. The override point does not disappear
+— it migrates to a plugin hook (`.research/001-plugins/`): real use cases
+exist (case-insensitive field lookup, lazy row proxies, virtual variables,
+soft-fail resolution), they just must not tax expressions that don't use
+them. **Impact: Low** (cleanup, not a speedup), but simplifies the mental
+model.
 
 ---
 
@@ -295,7 +375,10 @@ chained operations, extensions). Eliminating the args array on every call
 is a large allocation reduction.
 
 Currying (`#`) can stay as-is structurally, but should emit the same inline
-pattern inside the curried wrapper.
+pattern inside the curried wrapper. Note the current curry emission
+`(scope=>(a0)=>call(...))(scope)` allocates two closures per evaluation of
+the curry site even when the resulting function is never called; after §4b
+the outer scope-capturing IIFE becomes unnecessary.
 
 ---
 
@@ -373,7 +456,11 @@ _nc(L, ()=>(R))  // still a thunk — worse
 ```
 
 The hoisted-temp version needs the code generator to declare temp slots at
-the outer function level. Doable but more invasive.
+the outer function level. That capability is shared infrastructure — see
+"Shared infrastructure: temp slots" below; once it exists, this item is
+trivial. Note the temp must be unique per nesting depth: nested `??` and
+re-entrant evaluation through lambdas must not clobber a single shared
+slot (guard tests: `test/semantics-guards.test.ts`).
 
 **Impact: Low.** V8 handles this pattern well.
 
@@ -433,9 +520,44 @@ temp. For a pipe `H | S1 | S2 |? S3`:
  _t)
 ```
 
-`%` inside each stage is just `_t` — no scope frame needed at all. `|>`
-raises a `CompileError` at compile time (today it is a runtime throw
-inside the helper).
+`%` inside each stage is just `_t` — no scope frame needed at all. Only `|`
+and `|?` exist in the emission — both with statically known semantics, so
+the comma-chain needs no conditional branch per stage kind (see the `|>`
+note below).
+
+**Correctness caveat — `%` captured by closures.** A lambda (or curry
+site) defined inside a stage may capture `%` and be invoked *later*, after
+`_t` has been reassigned by subsequent stages:
+
+```js
+1 | (() => %) | %()        // must return 1, not the lambda itself
+```
+
+With a single shared `_t`, the escaped lambda would read the temp's
+*current* value at call time instead of the topic it closed over. The
+emission must therefore bind the topic per stage — e.g. emit each stage as
+an arrow taking the topic as a parameter, `(_t => (stage))(prev)` — either
+for every stage (one cheap arrow per stage per evaluation, still strictly
+better than today's descriptor objects + array + iterator allocation), or
+only for stages whose subtree contains a `LambdaExpression` or curry
+placeholder with a free `%`. Nested pipes need one distinct binding per
+pipe level.
+
+**Correctness caveat — `|?` terminates the whole pipe.** The emission
+sketch above guards only the single `|?` stage, but today's `defaultPipe`
+*returns from the entire pipe* when `|?` sees `null`/`undefined`/`NaN` —
+later stages, including plain `|` ones, do not run
+(`a | b |? c | d` with `b` → `null` yields `null`, never reaching `d`).
+The inline emission must therefore nest the *remainder* of the chain into
+the non-null branch of each `|?` conditional, not just the next stage:
+
+```js
+// H | S1 |? S2 | S3 →
+(_t=(H), _t=(S1),
+ (_t==null||_t!==_t) ? _t : (_t=(S2), _t=(S3), _t))
+```
+
+Guard tests pinning both caveats: `test/semantics-guards.test.ts`.
 
 **Prerequisites:**
 
@@ -443,8 +565,16 @@ inside the helper).
 - Temp slot hoisting (shared with §7).
 
 **Impact: High** for pipe-heavy code; many stdlib chains will benefit
-substantially. This also removes the `pipe` override entry point — fine,
-since `|>` is no longer a runtime concept.
+substantially.
+
+`|>` note (decided 2026-07-04): the reserved `|>` operator is removed from
+the language **entirely — grammar included** — in the next major, together
+with the legacy `ContextOptions` removal. There is no `pipe` override entry
+point to preserve and no plugin hook replacing it (the hook was dropped from
+the plugin design). If this section is implemented before the major, the
+inline emission temporarily keeps the current runtime-throw branch for `|>`;
+the branch is deleted with the grammar. Removal checklist lives in
+`.plan/2026-07-04/fork-decisions.md`, fork 1.
 
 ---
 
@@ -469,6 +599,11 @@ export function numAdd(a, b) {
 
 JITs can inline these at the call site, whereas `numericOp((a,b)=>a+b)`'s
 inner arrow hides behind a closure. **Impact: Medium.**
+
+House the fused helpers in `runtime.ts` so `interpret()` picks them up
+too — the interpreter gets the same win for free, and the parity surface
+does not grow (unlike raw inline emission, which makes the operator
+semantics exist a second time inside generated code).
 
 Alternative, more aggressive: inline the type check inline in codegen as
 discussed in §1. Downside: much larger generated code.
@@ -509,6 +644,15 @@ resolution, it becomes:
 Or, if we drop the outer scope closure entirely (because we no longer
 need the chain at runtime), just a nested block expression via arrow.
 
+**Naming caveat:** once `let` bindings become real JS identifiers, user
+names can collide with codegen-internal ones — `data`, `ctx`, `scope`,
+`globals`, `params`, `topic`, `p0`, `a0`, `_v` are all valid SimplEx
+identifiers (`let data = 1, ...` is legal today and must not shadow the
+runtime `data` parameter that free-identifier lookup relies on). Emit
+mangled names (`u_x`-style or counter-based), exactly as lambda params
+already do (`p0`) — never the raw user name. Guard tests pinning this:
+`test/semantics-guards.test.ts`.
+
 **Impact: High** for `let`-heavy expressions.
 
 ---
@@ -534,8 +678,87 @@ they don't need source-mapped errors (benchmarks, trusted expressions) can
 opt out today — but perhaps the default should change for hot-path usage,
 or the wrapper should be elided when the expression provably cannot throw.
 
+An alternative to eliding: emit the `try/catch` *inside* the generated
+function itself (around the expression body). That removes the extra
+call layer while keeping error mapping intact.
+
 **Impact: Low** for normal use; **Medium** for extremely tight loops where
 the function call dominates.
+
+---
+
+## 15. Constant folding — absent today
+
+No folding pass exists: `1 + 2`, `"a" & "b"`, `not true`,
+`if true then a else b`, and template literals with constant parts all
+compile to runtime operator calls. Since most expressions are authored by
+LLM agents — which routinely embed constants and self-documenting
+intermediate values — an AST-level folding pass before codegen is cheap,
+effective, and shrinks the generated code as a bonus.
+
+Rules:
+
+- Fold only subtrees whose evaluation provably does not throw (`1 + "a"`
+  must remain a *runtime* error with a source location — folding must not
+  move the throw to compile time or change its type/message/location).
+- The pass runs on the AST (like `validate()`), shared by both backends,
+  so parity is preserved by construction.
+- `if true/false then ... else ...` folds to the taken branch; dead
+  branches are dropped (they were already validated).
+
+**Impact: Medium** (expression-dependent), **Effort: Small–Medium.**
+Independent of everything else — can land at any point.
+
+---
+
+## 16. Compile-time performance (out of scope, recorded explicitly)
+
+This roadmap targets evaluation speed. Compile throughput has its own
+costs, relevant when many expressions are compiled on the fly:
+
+- `combineVisitResults` (`src/visitors.ts`) builds output via `reduce` +
+  string/array concatenation — O(n²) in the number of code parts. A
+  push-based accumulator makes it linear.
+- Peggy parse dominates compile time for small expressions; nothing to do
+  short of a parser swap (non-goal).
+- An LRU compile cache keyed by `(expression, options identity)` speeds up
+  repeated compiles by orders of magnitude with zero compiler changes.
+
+These are not scheduled; they are listed so the scope cut is explicit.
+
+---
+
+## Shared infrastructure: temp slots (prerequisite for §5–§9)
+
+§5, §6, §7, §8 and §9 each independently assume a temp variable (`_f`,
+`_o`, `_v`, `_t`) that today's generator cannot produce: temps must be
+*declared* at the enclosing emitted-function level and *named uniquely*
+per nesting depth — nested `??`, nested pipes, and lambda bodies each
+need their own slot, and a single shared name is clobbered by re-entrant
+evaluation (see the §9 correctness caveat). Build this once — a small
+allocator in the traverse context that hands out `_v0, _v1, …` per
+enclosing emitted function and records which declarations to hoist — and
+all five items consume it. Without it, each item grows its own ad-hoc
+variant.
+
+---
+
+## Step 0 — benchmark harness (before any of the above)
+
+The repository currently has **no benchmarks**; every Impact rating in
+this document is an estimate. Two deserve explicit skepticism: dictionary
+lookups (`bop["+"]`) are near-free under V8 inline caches, so §1's win
+rests on eliminating the `numericOp` double call, not the dictionary; and
+V8 often sinks short-lived closures in the optimizing tier, so allocation
+wins should be measured, not assumed. The *safest* bets are the pure
+allocation eliminations: §3 thunks, §5 args array, §9 descriptor
+objects, §4a `findIndex` closure + `bind(data)`.
+
+Before phase-2 work starts: add a micro+macro benchmark suite (e.g.
+`mitata` / `tinybench`) over a fixed set of representative expressions
+(arith-heavy, pipe-heavy, lambda-heavy, property-heavy, mixed stdlib),
+run per-item before/after, and record the numbers next to each landed
+item in this document.
 
 ---
 
@@ -544,6 +767,7 @@ the function call dominates.
 | # | Area | Change | Impact | Effort |
 |---|---|---|---|---|
 | 4a | Identifier lookup | `indexOf` instead of `findIndex(closure)` | High | Trivial |
+| 4a | Identifier lookup | drop per-eval `_get.bind(data)`; pass `data` as arg | High | Trivial |
 | 3 | Logical ops | Inline `&&`/`\|\|`, drop thunks | High | Small |
 | 1 | Binary arith | Named helpers, drop dict + wrapper | High | Small |
 | 5 | Function call | Inline null-safe call, drop args array | High | Small |
@@ -554,21 +778,26 @@ the function call dominates.
 | 1 (eq) | `==`/`!=` | Emit raw `===`/`!==` | Medium | Trivial |
 | 6 | Property access | Split dot/computed/extension paths | Medium | Medium |
 | 10 | Numeric guards | Combine guard + op per helper | Medium | Small |
+| 15 | Constant folding | AST-level folding pass before codegen | Medium | Small–Medium |
+| — | Temp-slot allocator | shared codegen infra unblocking §5–§9 | — (enabler) | Small |
 | 7 | `??` | Hoisted temp via comma | Low | Medium |
 | 8 | `!` non-null assert | Inline | Low | Small |
 | 11 | `castToBoolean` | Emit `!!x` | Low | Trivial |
-| 14 | Error mapping | Elide wrapper when safe | Low–Medium | Medium |
+| 14 | Error mapping | Elide wrapper when safe, or inline try/catch | Low–Medium | Medium |
 
 ## Recommended order of attack
 
-1. **§4a — `findIndex` → `indexOf`.** Zero-risk, trivial, high impact.
-   Do this today regardless of the larger strategy.
+0. **Benchmark harness.** No measurements exist today; establish the
+   baseline first (see "Step 0" above) and re-measure after each item.
+1. **§4a — `findIndex` → `indexOf` + drop `_get.bind(data)`.** Zero-risk,
+   trivial, high impact. Do this today regardless of the larger strategy.
 2. **§3 — native `&&`/`||`.** Small surface change, closes a significant
    allocation source.
 3. **§1 + §2 — drop operator dictionaries.** Decide the story for
    `binaryOperators`/`unaryOperators`/`logicalOperators` options. If we
    commit to "no override", we remove them from `CompileOptions`.
-4. **§5 — inline function calls.** Also removes `callFunction` from
+4. **Temp-slot allocator + §5 — inline function calls.** The allocator
+   built here also unblocks §6–§9. Also removes `callFunction` from
    the override surface.
 5. **§4b + §12 + §9 — static scope resolution.** The headline change.
    This is the one feature that actually opens the door to emitting
@@ -576,7 +805,14 @@ the function call dominates.
    environment-tracking pass, shadowing logic, and careful test coverage
    for let/lambda/pipe interactions, but the payoff is large and it also
    simplifies the runtime surface enormously.
-6. Remaining items as cleanup.
+6. **§15 — constant folding.** Independent of everything else; schedule
+   opportunistically at any point.
+7. Remaining items as cleanup.
+
+Guard tests for the semantics-preservation caveats called out in §4b, §7,
+§9 and §12 live in `test/semantics-guards.test.ts` — they pass against the
+current implementation and exist to fail loudly if an optimization changes
+observable behavior.
 
 ## What to preserve
 
@@ -589,16 +825,28 @@ Extensibility that should **remain**:
 - **`errorMapper`** — engine-specific concern, must remain pluggable for
   non-V8 environments.
 
-Extensibility that can be **removed** under this proposal:
+Extensibility that **migrates to compile-time plugins**
+(`.research/001-plugins/` — the default lowering stops paying for it;
+expressions compiled with a plugin pay per overridden operation):
 
-- `unaryOperators`, `binaryOperators`, `logicalOperators` overrides.
-- `castToBoolean`, `castToString` overrides.
-- `getIdentifierValue`, `getProperty`, `callFunction`, `nonNullAssert`,
-  `pipe` overrides (the entire `ContextHelpers` interface as an override
-  point).
-- The `|>` pipe reserved-hook — becomes a compile-time error.
+| Today's option | Plugin surface |
+|---|---|
+| `unaryOperators`, `binaryOperators` | `plugin.operators.unary` / `.binary` (plain or guarded) |
+| `logicalOperators` | `plugin.operators.logical` (thunk signature preserved, see §3) |
+| `castToBoolean`, `castToString` | `plugin.helpers.castToBoolean` / `.castToString` |
+| `getIdentifierValue` | `plugin.helpers.getIdentifierValue` (see §4b invariants) |
+| `getProperty` | `plugin.helpers.getProperty` |
+| `callFunction` | `plugin.helpers.callFunction` |
+| `nonNullAssert` | `plugin.helpers.nonNullAssert` |
 
-If a future use case genuinely requires changing core semantics, a
-proper compiler-plugin mechanism can be designed for it at that point.
-Today it is dead configuration surface that costs performance on every
-evaluation.
+Removed outright, with no plugin replacement (decided 2026-07-04):
+
+- The `pipe` override and the reserved `|>` operator — deleted from the
+  language, grammar included, in the next major (see §9 note).
+
+The compiler-plugin mechanism itself is designed in `.research/001-plugins/`
+(semantic + transform plugins, mandatory `explain()`, migration path from
+`ContextOptions`). The override surface is not dead — it is mispriced: today
+every evaluation pays for extensibility nobody asked for. Plugins flip that
+to pay-per-use, and the migration path there (fast core → plugins →
+deprecation → removal in the next major) is the intended order of work.

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -119,3 +119,45 @@ Tree-walking is slower per call than JIT-compiled `new Function` output. `interp
 - `src/visitors.ts` — inline validations removed (moved to `validate.ts`).
 - `package.json` — `exports` entry `"./interpret"`.
 - `test/helpers.ts` — parity-`compile`; `test/interpreter.test.ts` — eval-free-specific cases.
+
+---
+
+## Lambda scope frames are per-invocation locals (issue #30)
+
+**Status:** Implemented (bug fix).
+
+### Context
+
+The codegen backend emitted lambdas as:
+
+```js
+((scope,params)=>function(p0){scope=[params,[p0],scope];return BODY})(scope,[...])
+```
+
+The generated function **reassigned the closure-captured `scope` variable** on every invocation and never restored it. All invocations of one lambda instance share that single binding, so after a recursive self-call returned, the scope-chain head was a stale frame from the completed recursion. Any `let`-bound recursive lambda with **two or more self-calls in one expression** resolved identifiers against the wrong frame (`fib(10)` → `-80`; a two-base-case variant overflowed the stack). Single-self-call patterns (`n * f(n - 1)`) worked only because JS evaluates operands left-to-right — every read of `n` happened before the recursive call polluted the chain.
+
+The interpreter builds a fresh frame per call (`evalNode(body, [paramNames, args, scope], data)`) and was always correct — a backend divergence the parity suite did not cover (no multi-self-call recursion cases existed).
+
+### Decision
+
+Bind the frame as a fresh per-invocation local instead of mutating the captured variable:
+
+```js
+((_scope,params)=>function(p0){var scope=[params,[p0],_scope];return BODY})(scope,[...])
+```
+
+Nested emissions inside `BODY` reference `scope` lexically and get the invocation's own frame; nested lambdas capture it correctly (real closure semantics).
+
+`LetExpression` and pipe-stage emissions also reassign a `scope` IIFE parameter, but those IIFEs are invoked once per *evaluation* of the enclosing expression, so the reassignment is local and harmless — reviewed and left unchanged.
+
+### Consequences
+
+- Mutual recursion between sibling `let` bindings now works reliably on both backends (bindings share one frame; lambda bodies resolve names at call time). Documentation previously claimed it was unsupported — corrected in `README.md`, `docs/js-comparison.md`, `docs/agent-guide.md`.
+- The multi-branch recursion workaround (binding each self-call with `let` first) is now a stylistic choice, not a requirement.
+- Regression suite: `test/recursion.test.ts` (parity — both backends).
+- The scope-chain mechanism itself is slated for removal by static scope resolution (`docs/compiler-roadmap.md` §4b); the regression tests must survive that rewrite.
+
+### Affected files
+
+- `src/visitors.ts` — `LambdaExpression` codegen.
+- `test/recursion.test.ts` — new regression suite.

--- a/docs/js-comparison.md
+++ b/docs/js-comparison.md
@@ -77,7 +77,7 @@ The README's [Like JS, but…](../README.md#like-js-but) section is a short summ
 | Spread in call sites | `f(...arr)` | **no** | the call must list arguments. For variadic stdlib, use the namespace form (`Math.max(a, b, c)`); to apply over an array, fold: `Arr.fold(arr, (a, b) => Math.max(a, b))` |
 | Currying placeholder | — | `#` inside call arguments — `add(#, 3)` is `x => add(x, 3)` | `#` only works inside call arguments; it is not a general-purpose hole |
 | Named recursion | yes | yes — a `let` binding whose initializer is a lambda can call itself by name; see the [Recursion](../README.md#recursion) section |
-| Mutual recursion | yes | **no** — sibling `let` bindings cannot see each other |
+| Mutual recursion | yes | yes — sibling `let` bindings share one scope; lambda bodies resolve names at call time |
 | Generators / `yield` | yes | **no** | |
 | async / await, Promise | yes | **no** | every expression is synchronous |
 | `new`, constructors | yes | **no** | values are produced by literals and by globals you provide |
@@ -113,7 +113,7 @@ The README's [Like JS, but…](../README.md#like-js-but) section is a short summ
 | Reassignment | `x = y` | **no** — bindings are immutable | re-bind with a new `let`: `let x = …, let x = newValue, …` |
 | Hoisting | yes | **no** — a name is in scope only after its `let` binding is established (the lambda case is the one exception, see below) |
 | Self-reference in a binding | `const x = x + 1` is a TDZ error | identical for non-lambdas (`let x = x + 1, x` errors); **works** when the initializer is a lambda — the name is captured by closure and resolved at call time |
-| Mutual recursion | yes | **no** — two sibling `let` bindings cannot reference each other |
+| Mutual recursion | yes | yes — a lambda body sees all sibling bindings at call time; only *initializers* are restricted to previous bindings |
 | TDZ | yes | not a category — there is no hoisting, so the question doesn't arise |
 
 ---

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -67,7 +67,7 @@ let sumTree = node =>
 sumTree(root)
 ```
 
-**Why.** Two recursive calls in one expression are not a problem, but if the recursive case **branches** (Fibonacci-style), bind each call with `let` first to keep the structure flat (see [Multi-branch recursion](../README.md#recursion) in the README).
+**Why.** Multiple recursive calls in one expression are fine (see [Recursion](../README.md#recursion) in the README). Binding each call with `let` first (`let a = f(n - 1), b = f(n - 2), a + b`) is a stylistic option that keeps a busy recursive case flat — not a requirement.
 
 ---
 

--- a/src/visitors.ts
+++ b/src/visitors.ts
@@ -308,9 +308,14 @@ const visitors: {
       const fnParamsList = fnParams.join()
       const fnParamsNamesList = paramsNames.map(p => JSON.stringify(p)).join()
 
+      // The frame must be a fresh per-invocation local (`var scope`), NOT a
+      // reassignment of the closure-captured variable: all invocations of one
+      // lambda instance share that captured binding, so mutating it leaks
+      // frames of completed calls into subsequent ones (breaks expressions
+      // with two+ recursive self-calls, e.g. Fibonacci — see issue #30).
       const parts: VisitResult[] = [
         codePart(
-          `((${GEN.scope},params)=>function(${fnParamsList}){${GEN.scope}=[params,[${fnParamsList}],${GEN.scope}];return `,
+          `((${GEN._scope},params)=>function(${fnParamsList}){var ${GEN.scope}=[params,[${fnParamsList}],${GEN._scope}];return `,
           node
         ),
         ...visit(node.expression),

--- a/test/recursion.test.ts
+++ b/test/recursion.test.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict'
+import { suite, test } from 'node:test'
+import { compile } from './helpers.js'
+
+/**
+ * Regression tests for issue #30: the codegen backend reassigned the
+ * closure-captured `scope` variable on every lambda invocation, leaking
+ * frames of completed calls into subsequent ones. Any recursive lambda with
+ * two or more self-calls in one expression resolved identifiers against a
+ * stale frame after the first self-call returned.
+ *
+ * All cases run through the parity helper, so both backends are covered.
+ */
+
+suite('recursion: multiple self-calls per expression (issue #30)', () => {
+  test('fibonacci via named let-recursion', () => {
+    const fn = compile(
+      'let f = n => if n <= 1 then n else f(n - 1) + f(n - 2), f(10)'
+    )
+    assert.equal(fn(), 55)
+  })
+
+  test('minimal case: fib(2)', () => {
+    const fn = compile(
+      'let f = n => if n <= 1 then n else f(n - 1) + f(n - 2), f(2)'
+    )
+    assert.equal(fn(), 1)
+  })
+
+  test('two base cases (previously stack overflow)', () => {
+    const fn = compile(
+      'let f = n => if n == 0 then 0 else if n == 1 then 1 else f(n - 1) + f(n - 2), f(10)'
+    )
+    assert.equal(fn(), 55)
+  })
+
+  test('two identical self-calls', () => {
+    const fn = compile(
+      'let f = n => if n <= 1 then 2 else f(n - 1) * f(n - 1), f(3)'
+    )
+    assert.equal(fn(), 16)
+  })
+
+  test('three self-calls', () => {
+    const fn = compile(
+      'let f = n => if n <= 1 then 1 else f(n - 1) + f(n - 1) + f(n - 1), f(3)'
+    )
+    assert.equal(fn(), 9)
+  })
+
+  test('self-call followed by a non-recursive operand', () => {
+    const fn = compile(
+      'let f = n => if n <= 0 then 1 else f(n - 1) + 100, f(3)'
+    )
+    assert.equal(fn(), 301)
+  })
+
+  test('self-calls inside an array literal', () => {
+    const fn = compile(
+      'let f = n => if n <= 1 then n else [f(n - 1), f(n - 2)], f(3)'
+    )
+    assert.deepEqual(fn(), [[1, 0], 1])
+  })
+
+  test('self-calls passed as arguments to a global function', () => {
+    const fn = compile(
+      'let f = n => if n <= 1 then n else add(f(n - 1), f(n - 2)), f(10)',
+      { globals: { add: (a: number, b: number) => a + b } }
+    )
+    assert.equal(fn(), 55)
+  })
+
+  test('named recursion inside a pipe stage', () => {
+    const fn = compile(
+      '10 | (let f = n => if n <= 1 then n else f(n - 1) + f(n - 2), f(%))'
+    )
+    assert.equal(fn(), 55)
+  })
+})
+
+suite('recursion: patterns that already worked (regression)', () => {
+  test('factorial (single self-call)', () => {
+    const fn = compile(
+      'let f = n => if n <= 1 then 1 else n * f(n - 1), f(5)'
+    )
+    assert.equal(fn(), 120)
+  })
+
+  test('countdown (self-call under spread)', () => {
+    const fn = compile(
+      'let f = n => if n <= 0 then [] else [n, ...f(n - 1)], f(3)'
+    )
+    assert.deepEqual(fn(), [3, 2, 1])
+  })
+
+  test('fibonacci via let-extraction of self-call results', () => {
+    const fn = compile(
+      'let f = n => if n <= 1 then n else let a = f(n - 1), b = f(n - 2), a + b, f(10)'
+    )
+    assert.equal(fn(), 55)
+  })
+
+  test('self(self) trick', () => {
+    const fn = compile(
+      'let f = self => n => if n <= 1 then n else self(self)(n - 1) + self(self)(n - 2), f(f)(10)'
+    )
+    assert.equal(fn(), 55)
+  })
+
+  test('Y combinator', () => {
+    const fn = compile(
+      'let Y = f => (x => f(y => x(x)(y)))(x => f(y => x(x)(y))), Y(self => n => if n <= 1 then n else self(n - 1) + self(n - 2))(10)'
+    )
+    assert.equal(fn(), 55)
+  })
+})
+
+suite('recursion: mutual recursion via sibling let bindings', () => {
+  // Sibling bindings live in one shared frame; a lambda body resolves names
+  // at call time, so an earlier binding can call a later one.
+  test('even/odd', () => {
+    const fn = compile(
+      'let even = n => if n == 0 then true else odd(n - 1), odd = n => if n == 0 then false else even(n - 1), even(x)'
+    )
+    assert.equal(fn({ x: 10 }), true)
+    assert.equal(fn({ x: 7 }), false)
+  })
+
+  test('initializers still cannot see later siblings', () => {
+    // Only call-time resolution works; init-time evaluation of a later name
+    // must throw.
+    const fn = compile('let a = b, b = 1, a')
+    assert.throws(() => fn(), /Unknown identifier - b/)
+  })
+})

--- a/test/semantics-guards.test.ts
+++ b/test/semantics-guards.test.ts
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict'
+import { suite, test } from 'node:test'
+import { compile } from './helpers.js'
+
+/**
+ * Guard tests for the planned codegen optimizations in
+ * `docs/compiler-roadmap.md`. Each case pins observable behavior that a
+ * future optimization could silently break:
+ *
+ * - §9 (inline pipes): `%` captured by a closure must keep the topic value
+ *   of its own stage — not read a shared mutable temp at call time.
+ * - §12 (let → real JS locals): user binding names that collide with
+ *   codegen-internal identifiers must not shadow runtime plumbing.
+ * - §4b (static identifier resolution): direct data/globals emission must
+ *   preserve hasOwn semantics, unknown-identifier errors, the `undefined`
+ *   special case, and by-reference globals reads.
+ * - §7 (hoisted `??` temps): nested and re-entrant `??` evaluation must
+ *   not clobber a shared temp slot.
+ *
+ * All cases run through the parity helper, so both backends are covered.
+ */
+
+suite('semantics guards: pipe topic capture (§9)', () => {
+  test('lambda capturing % is called in a later stage', () => {
+    assert.equal(compile('1 | (() => %) | %()')(), 1)
+  })
+
+  test('lambda capturing % is called after the pipe completes', () => {
+    assert.equal(compile('let f = (1 | (() => %)), f()')(), 1)
+  })
+
+  test('lambda capturing % is invoked within its own stage', () => {
+    assert.equal(compile('10 | (() => %)()')(), 10)
+  })
+
+  test('nested pipe: escaped lambda keeps the inner topic', () => {
+    assert.equal(compile('1 | (10 | (() => %)) | %()')(), 10)
+  })
+
+  test('lambda captures outer % from inside a nested pipe stage', () => {
+    // Inner pipe reassigns the topic; the lambda made in the inner stage
+    // must still see the *inner* topic, while the outer stage sees the
+    // outer one.
+    assert.equal(compile('1 | (20 | % + 1) + %')(), 22)
+  })
+
+  test('curry site capturing % is applied in a later stage', () => {
+    const fn = compile('10 | add(#, %) | %(5)', {
+      globals: { add: (a: number, b: number) => a + b }
+    })
+    assert.equal(fn(), 15)
+  })
+
+  test('|? short-circuits the whole remaining pipe, captured topics intact', () => {
+    // `|?` on null returns from the ENTIRE pipe (later stages, including
+    // plain `|`, do not run) — the §9 inline emission must keep that.
+    assert.equal(compile('1 | (() => %) | null |? %() | 7')(), null)
+    assert.equal(compile('1 | (() => %) |? %()')(), 1)
+  })
+})
+
+suite('semantics guards: codegen-internal name collisions (§12)', () => {
+  test('let binding named "data" does not break free identifier lookup', () => {
+    assert.equal(compile('let data = 1, data + a')({ a: 2 }), 3)
+  })
+
+  test('let binding named "scope"', () => {
+    assert.equal(compile('let scope = 5, scope + a')({ a: 1 }), 6)
+  })
+
+  test('let binding named "ctx"', () => {
+    assert.equal(compile('let ctx = 2, ctx * a')({ a: 3 }), 6)
+  })
+
+  test('let binding named "globals" does not shadow real globals', () => {
+    assert.equal(
+      compile('let globals = 7, globals + g', { globals: { g: 1 } })(),
+      8
+    )
+  })
+
+  test('lambda param named "params"', () => {
+    assert.equal(compile('(params => params + a)(1)')({ a: 2 }), 3)
+  })
+
+  test('lambda param named "topic" inside a pipe stage', () => {
+    assert.equal(compile('5 | (topic => topic + %)(2)')(), 7)
+  })
+
+  test('lambda params named like mangled codegen params (p0, p1)', () => {
+    assert.equal(compile('(p0 => p0 + 1)(41)')(), 42)
+    assert.equal(compile('((p1, p0) => p0 - p1)(1, 2)')(), 1)
+  })
+
+  test('let binding named "_v" (?? temp candidate)', () => {
+    assert.equal(compile('let _v = null, _v ?? 5')(), 5)
+    assert.equal(compile('let _v = 1, _v ?? 5')(), 1)
+  })
+
+  test('let binding named "topic" alongside % in a pipe', () => {
+    assert.equal(compile('let topic = 1, (2 | % + topic)')(), 3)
+  })
+})
+
+suite('semantics guards: identifier resolution (§4b)', () => {
+  test('unknown identifier throws', () => {
+    const fn = compile('missing')
+    assert.throws(() => fn({}), /Unknown identifier - missing/)
+  })
+
+  test('inherited data properties are invisible (hasOwn semantics)', () => {
+    const fn = compile('inherited')
+    const data = Object.create({ inherited: 42 }) as Record<string, unknown>
+    assert.throws(() => fn(data), /Unknown identifier - inherited/)
+  })
+
+  test('Object.prototype members are not resolvable as identifiers', () => {
+    const fn = compile('toString')
+    assert.throws(() => fn({}), /Unknown identifier - toString/)
+  })
+
+  test('`undefined` resolves to undefined even with an own "undefined" key', () => {
+    assert.equal(compile('undefined')({ undefined: 5 }), undefined)
+    assert.equal(
+      compile('undefined', { globals: { undefined: 5 } })(),
+      undefined
+    )
+  })
+
+  test('globals are read by reference: mutation after compile is visible', () => {
+    // Pins today's by-reference semantics. Folding global VALUES at
+    // compile time (roadmap §4b) would switch this to snapshot semantics —
+    // that must be an explicit, documented decision, not a side effect.
+    const globals: Record<string, unknown> = { x: 1 }
+    const fn = compile('x', { globals })
+    assert.equal(fn(), 1)
+    globals['x'] = 2
+    assert.equal(fn(), 2)
+  })
+})
+
+suite('semantics guards: nullish coalescing nesting (§7)', () => {
+  test('sibling ?? expressions do not interfere', () => {
+    assert.equal(compile('(a ?? 1) + (b ?? 2)')({ a: null, b: null }), 3)
+    assert.equal(compile('(a ?? 1) + (b ?? 2)')({ a: 10, b: null }), 12)
+  })
+
+  test('nested ?? on the right side', () => {
+    assert.equal(compile('a ?? (b ?? 3)')({ a: null, b: null }), 3)
+    assert.equal(compile('a ?? (b ?? 3)')({ a: null, b: 2 }), 2)
+  })
+
+  test('nested ?? on the left side', () => {
+    assert.equal(compile('(a ?? b) ?? c')({ a: null, b: null, c: 5 }), 5)
+    assert.equal(compile('(a ?? b) ?? c')({ a: null, b: 4, c: 5 }), 4)
+  })
+
+  test('re-entrant ?? through an immediately-invoked lambda', () => {
+    assert.equal(compile('null ?? (() => (null ?? 7))()')(), 7)
+  })
+
+  test('recursive lambda with ?? in its body', () => {
+    const fn = compile(
+      'let f = n => if n == 0 then (x ?? 99) else (f(n - 1) ?? -1), f(2)'
+    )
+    assert.equal(fn({ x: null }), 99)
+    assert.equal(fn({ x: 7 }), 7)
+  })
+})

--- a/test/traverse.test.ts
+++ b/test/traverse.test.ts
@@ -204,12 +204,12 @@ suite('traverse code', () => {
   test('lambda', () => {
     assert.equal(
       getCode('a => b'),
-      '((scope,params)=>function(p0){scope=[params,[p0],scope];return get(scope,"b")})(scope,["a"])'
+      '((_scope,params)=>function(p0){var scope=[params,[p0],_scope];return get(scope,"b")})(scope,["a"])'
     )
 
     assert.equal(
       getCode('a => (b) => a + b + c'),
-      '((scope,params)=>function(p0){scope=[params,[p0],scope];return ((scope,params)=>function(p0){scope=[params,[p0],scope];return bop["+"](bop["+"](get(scope,"a"),get(scope,"b")),get(scope,"c"))})(scope,["b"])})(scope,["a"])'
+      '((_scope,params)=>function(p0){var scope=[params,[p0],_scope];return ((_scope,params)=>function(p0){var scope=[params,[p0],_scope];return bop["+"](bop["+"](get(scope,"a"),get(scope,"b")),get(scope,"c"))})(scope,["b"])})(scope,["a"])'
     )
   })
 


### PR DESCRIPTION
## Summary

Fixes the codegen-backend bug where a `let`-bound recursive lambda with **two or more self-calls in one expression** returned wrong results (`fib(10)` → `-80`) or overflowed the stack. The eval-free `interpret()` backend was always correct — a backend divergence the parity suite did not cover.

**Root cause:** `LambdaExpression` codegen reassigned the closure-captured `scope` variable on every invocation and never restored it, so after the first self-call returned, subsequent identifier lookups resolved against a stale frame of the completed recursion.

**Fix (one line of emission):** bind the frame as a fresh per-invocation local:

```js
// before
((scope,params)=>function(p0){scope=[params,[p0],scope];return BODY})(scope,[...])
// after
((_scope,params)=>function(p0){var scope=[params,[p0],_scope];return BODY})(scope,[...])
```

`LetExpression` and pipe-stage emissions reassign an IIFE parameter that is fresh per evaluation and invoked once — reviewed and left unchanged.

## Also in this PR

- **Docs correction:** mutual recursion between sibling `let` bindings works (verified on both backends, now pinned by tests) — README / js-comparison / agent-guide claimed otherwise. The multi-branch recursion `let`-extraction workaround is now documented as a stylistic choice.
- **New parity regression suite** `test/recursion.test.ts` — fib variants (incl. former stack-overflow case), self-calls in arrays/args, recursion inside a pipe stage, factorial/countdown/self(self)/Y-combinator, mutual recursion.
- **Decision record** in `docs/design-decisions.md`; roadmap §4b notes the regression suite must survive the static-scope-resolution rewrite.
- First commit carries the compiler-roadmap review updates and `test/semantics-guards.test.ts` from the same working session (guard tests for planned roadmap optimizations).

## Test plan

- [x] `npm test` — 390/390 pass (build + lint + coverage), both backends via parity helper
- [x] Manual repro matrix from `.plan/compiler-bug.md` re-verified

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)